### PR TITLE
Fix infinite recursion in get_CID_dilutions

### DIFF
--- a/opc_python/utils/loading.py
+++ b/opc_python/utils/loading.py
@@ -284,9 +284,9 @@ def get_CID_dilutions(kind, target_dilution=None, cached=True):
             data = list(set(data))
         elif kind == 'training-norep':
             training = set(get_CID_dilutions('training',
-                                             target_dilution=target_dilution))
+                                             target_dilution=target_dilution, cached=cached))
             replicated = set(get_CID_dilutions('replicated',
-                                               target_dilution=target_dilution))
+                                               target_dilution=target_dilution, cached=cached))
             data = list(training.difference(replicated))
     data = sorted(data)
     return data


### PR DESCRIPTION
`get_CID_dilutions` enters an infinite loop when called with `cached=True` if the cached files it is looking for do not exist, because in that case it calls `pickle_CID_dilutions` to create those files, which calls `get_CID_dilutions` to generate them.  This second recursive call of `get_CID_dilutions` would be okay on its own, since it uses the `cached=False` flag, but one of the recursive calls also passes `kind='training-norep'`, which causes `get_CID_dilutions` to recurse a third time, this time not forwarding the `cached=False` flag that prevents it from entering an infinite loop.  Forwarding `cached=False` to the third layer of recursive calls should fix this problem.