### PR TITLE
Fix progress bar exceeding 100%

### DIFF
--- a/opc_python/gerkin/fit2.py
+++ b/opc_python/gerkin/fit2.py
@@ -52,11 +52,11 @@ def rfc_final(X,Y,Y_imp,
                    n_jobs=-1, random_state=seed, **kwargs)
        
     n_descriptors = len(descriptors) 
-    p = ProgressBar(n_descriptors)
+    p = ProgressBar(n_descriptors * 2)
     rfcs = {x:{} for x in ('mean','std')}
     for d,descriptor in enumerate(descriptors*2):
-        p.animate(d,"Fitting %s" % descriptor)
         kind = 'std' if d >= len(descriptors) else 'mean'
+        p.animate(d,"Fitting %s %s" % (descriptor, kind))
         rfcs[kind][descriptor] = rfc_maker(n_estimators=n_estimators,
                                         max_features=max_features[d],
                                         min_samples_leaf=min_samples_leaf[d],


### PR DESCRIPTION
When running the fit in `challenge2.ipynb`, the progress bar is configured for a maximum of 21 items, but the actual fitting loop processes 42 items (each descriptor is fit twice, once for mean and once for standard deviation).  This causes the progress bar to appear to exceed 100% as it progresses past the 21st item.  Changing the scale of the progress bar to `n_descriptors * 2` should bring it into agreement with reality.